### PR TITLE
Periodic checks

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -4,18 +4,24 @@ import (
 	"encoding/json"
 	"fmt"
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
+	"log"
 	"net/http"
+	"time"
 )
 
 type hchandlers struct {
-	registry    ServiceRegistry
-	checker     ServiceHealthChecker
-	name        string
-	description string
+	registry     ServiceRegistry
+	checker      ServiceHealthChecker
+	name         string
+	description  string
+	latestResult <-chan fthealth.HealthResult
 }
 
 func NewHCHandlers(registry ServiceRegistry, checker ServiceHealthChecker) *hchandlers {
-	return &hchandlers{registry, checker, "Coco Aggregate Healthcheck", "Checks the health of all deployed services"}
+	lr := make(chan fthealth.HealthResult)
+	hch := &hchandlers{registry, checker, "Coco Aggregate Healthcheck", "Checks the health of all deployed services", lr}
+	go hch.loop(lr)
+	return hch
 }
 
 func (hch *hchandlers) handle(w http.ResponseWriter, r *http.Request) {
@@ -27,16 +33,36 @@ func (hch *hchandlers) handle(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func (hch *hchandlers) result() fthealth.HealthResult {
-	checks := []fthealth.Check{}
-	for _, service := range hch.registry.Services() {
-		checks = append(checks, NewCocoServiceHealthCheck(service, hch.checker))
+func (hch *hchandlers) loop(lr chan<- fthealth.HealthResult) {
+
+	newResult := make(chan fthealth.HealthResult)
+
+	go func() {
+		for {
+			checks := []fthealth.Check{}
+			for _, service := range hch.registry.Services() {
+				checks = append(checks, NewCocoServiceHealthCheck(service, hch.checker))
+			}
+			start := time.Now()
+			health := fthealth.RunCheck(hch.name, hch.description, true, checks...)
+			log.Printf("got new health results in %v\n", time.Now().Sub(start))
+			newResult <- health
+			time.Sleep(60 * time.Second)
+		}
+	}()
+
+	var latest fthealth.HealthResult
+	for {
+		select {
+		case latest = <-newResult:
+		case lr <- latest:
+		}
+
 	}
-	return fthealth.RunCheck(hch.name, hch.description, true, checks...)
 }
 
 func (hch *hchandlers) jsonHandler(w http.ResponseWriter, r *http.Request) {
-	health := hch.result()
+	health := <-hch.latestResult
 
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
@@ -63,7 +89,7 @@ func (hch *hchandlers) htmlHandler(w http.ResponseWriter, r *http.Request) {
 	serviceHtmlTemplate := "<dd>- <a href=\"%s\">%s</a>  : %s</dd>"
 	servicesHtml := ""
 
-	checkResult := hch.result()
+	checkResult := <-hch.latestResult
 	for _, check := range checkResult.Checks {
 		serviceHealthUrl := fmt.Sprintf("/health/%s/__health", check.Name)
 		if !check.Ok {

--- a/handlers.go
+++ b/handlers.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/Financial-Times/go-fthealth"
+	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	"net/http"
 )
 

--- a/handlers.go
+++ b/handlers.go
@@ -7,65 +7,73 @@ import (
 	"net/http"
 )
 
-func CocoAggregateHealthHandler(registry ServiceRegistry, checker ServiceHealthChecker) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		checks := []fthealth.Check{}
-		for _, service := range registry.Services() {
-			checks = append(checks, NewCocoServiceHealthCheck(service, checker))
-		}
+type hchandlers struct {
+	registry    ServiceRegistry
+	checker     ServiceHealthChecker
+	name        string
+	description string
+}
 
-		if r.Header.Get("Accept") == "application/json" {
-			jsonHandler("Coco Aggregate Healthcheck", "Checks the health of all deployed services", checks...)(w, r)
+func NewHCHandlers(registry ServiceRegistry, checker ServiceHealthChecker) *hchandlers {
+	return &hchandlers{registry, checker, "Coco Aggregate Healthcheck", "Checks the health of all deployed services"}
+}
+
+func (hch *hchandlers) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Accept") == "application/json" {
+		hch.jsonHandler(w, r)
+	} else {
+		hch.htmlHandler(w, r)
+	}
+
+}
+
+func (hch *hchandlers) checks() []fthealth.Check {
+	checks := []fthealth.Check{}
+	for _, service := range hch.registry.Services() {
+		checks = append(checks, NewCocoServiceHealthCheck(service, hch.checker))
+	}
+	return checks
+}
+
+func (hch *hchandlers) jsonHandler(w http.ResponseWriter, r *http.Request) {
+	health := fthealth.RunCheck(hch.name, hch.description, true, hch.checks()...)
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	err := enc.Encode(health)
+	if err != nil {
+		panic("write this bit")
+	}
+}
+
+func (hch *hchandlers) htmlHandler(w http.ResponseWriter, r *http.Request) {
+	resp := "<!DOCTYPE html>" +
+		"<head>" +
+		"<title>Coco</title>" +
+		"</head>" +
+		"<body>" +
+		"<h2>%s</h2>" +
+		"<dl>" +
+		"<dt>Services:</dt>" +
+		"%s" +
+		"</dl>" +
+		"</body>" +
+		"</html>"
+
+	serviceHtmlTemplate := "<dd>- <a href=\"%s\">%s</a>  : %s</dd>"
+	servicesHtml := ""
+
+	checkResult := fthealth.RunCheck(hch.name, hch.description, true, hch.checks()...)
+	for _, check := range checkResult.Checks {
+		serviceHealthUrl := fmt.Sprintf("/health/%s/__health", check.Name)
+		if !check.Ok {
+			servicesHtml += fmt.Sprintf(serviceHtmlTemplate, serviceHealthUrl, check.Name, "CRITICAL")
 		} else {
-
-			htmlHandler("Coco Aggregate Healthcheck", "Checks the health of all deployed services", checks...)(w, r)
-		}
-	}
-}
-
-func jsonHandler(name, description string, checks ...fthealth.Check) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		health := fthealth.RunCheck(name, description, true, checks...)
-
-		w.Header().Set("Content-Type", "application/json")
-		enc := json.NewEncoder(w)
-		err := enc.Encode(health)
-		if err != nil {
-			panic("write this bit")
-		}
-	}
-}
-
-func htmlHandler(name, description string, checks ...fthealth.Check) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		resp := "<!DOCTYPE html>" +
-			"<head>" +
-			"<title>Coco</title>" +
-			"</head>" +
-			"<body>" +
-			"<h2>%s</h2>" +
-			"<dl>" +
-			"<dt>Services:</dt>" +
-			"%s" +
-			"</dl>" +
-			"</body>" +
-			"</html>"
-
-		serviceHtmlTemplate := "<dd>- <a href=\"%s\">%s</a>  : %s</dd>"
-		servicesHtml := ""
-
-		checkResult := fthealth.RunCheck(name, name, true, checks...)
-		for _, check := range checkResult.Checks {
-			serviceHealthUrl := fmt.Sprintf("/health/%s/__health", check.Name)
-			if !check.Ok {
-				servicesHtml += fmt.Sprintf(serviceHtmlTemplate, serviceHealthUrl, check.Name, "CRITICAL")
-			} else {
-				servicesHtml += fmt.Sprintf(serviceHtmlTemplate, serviceHealthUrl, check.Name, "OK")
-			}
-
+			servicesHtml += fmt.Sprintf(serviceHtmlTemplate, serviceHealthUrl, check.Name, "OK")
 		}
 
-		w.Header().Add("Content-Type", "text/html")
-		fmt.Fprintf(w, resp, name, servicesHtml)
 	}
+
+	w.Header().Add("Content-Type", "text/html")
+	fmt.Fprintf(w, resp, hch.name, servicesHtml)
 }

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	registry := NewCocoServiceRegistry(etcd, *keyPrefix, *vulcand)
 	checker := NewCocoServiceHealthChecker(&http.Client{Transport: transport, Timeout: 10 * time.Second})
-	handler := CocoAggregateHealthHandler(registry, checker)
+	handler := NewHCHandlers(registry, checker).handle
 
 	r := mux.NewRouter()
 	r.HandleFunc("/", handler)


### PR DESCRIPTION
    Run checks every minute in the background.
    
    Whenever things are busy/broken everyone (understandably) jumps onto the
    aggregate healthcheck to see whats wrong.  For each request, we kick of
    n*more requests to the back end apps.  The end result contributes to
    massive network usage, and we've seen tens of thousands of tcp
    connections in the agg hc docker container.
    
    This change means we update a stored view of service health every
    minute, and when requesting we always return the same cached result
    immediately.
