### PR TITLE
Fail better without graphite

### DIFF
--- a/graphitefeeder.go
+++ b/graphitefeeder.go
@@ -50,7 +50,10 @@ func (graphite *GraphiteFeeder) sendBuffer(bufferGraphite chan *HealthTimed) err
 }
 
 func (graphite *GraphiteFeeder) sendPilotLight() error {
-	log.Printf("DEBUG " + pilotLightFormat, graphite.environment, time.Now().Unix())
+	if graphite.connection == nil {
+		return errors.New("No graphite connection")
+	}
+	log.Printf("DEBUG "+pilotLightFormat, graphite.environment, time.Now().Unix())
 	_, err := fmt.Fprintf(graphite.connection, pilotLightFormat, graphite.environment, time.Now().Unix())
 	if err != nil {
 		log.Printf("WARN Error sending pilot-light signal to graphite: [%v]", err.Error())


### PR DESCRIPTION
Currently panics with null pointer if unable to connect to graphite:

```
Dec 29 10:05:47 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: 172.24.55.177 - - [29/Dec/2015:10:05:47 +0000] "GET /__health HTTP/1.1" 200 4393
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: 2015/12/29 10:05:53 DEBUG coco.health.prod-uk.pilot-light 1 1451383553
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: panic: runtime error: invalid memory address or nil pointer dereference
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: [signal 0xb code=0x1 addr=0x20 pc=0x496e96]
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: goroutine 9 [running]:
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: fmt.Fprintf(0x0, 0x0, 0xb1e0b0, 0x20, 0xc2081f9f38, 0x2, 0x2, 0xc2080363b8, 0x0, 0x0)
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/fmt/print.go:189 +0xa6
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: main.(*GraphiteFeeder).sendPilotLight(0xc208033300, 0x0, 0x0)
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /aggregate-healthcheck/graphitefeeder.go:54 +0x35c
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: main.(*GraphiteFeeder).maintainGraphiteFeed(0xc208033300, 0xc208036300, 0xc208033340)
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /aggregate-healthcheck/graphitefeeder.go:29 +0x7f
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: created by main.NewHCHandlers
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /aggregate-healthcheck/handlers.go:47 +0x299
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: goroutine 1 [IO wait]:
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net.(*pollDesc).Wait(0xc208010a00, 0x72, 0x0, 0x0)
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/fd_poll_runtime.go:84 +0x47
Dec 29 10:05:53 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net.(*pollDesc).WaitRead(0xc208010a00, 0x0, 0x0)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/fd_poll_runtime.go:89 +0x43
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net.(*netFD).accept(0xc2080109a0, 0x0, 0x7fb67c3b3d48, 0xc20824a280)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/fd_unix.go:419 +0x40b
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net.(*TCPListener).AcceptTCP(0xc20803a050, 0x4fa85e, 0x0, 0x0)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/tcpsock_posix.go:234 +0x4e
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net/http.tcpKeepAliveListener.Accept(0xc20803a050, 0x0, 0x0, 0x0, 0x0)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/http/server.go:1976 +0x4c
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net/http.(*Server).Serve(0xc208036540, 0x7fb67c3b59f8, 0xc20803a050, 0x0, 0x0)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/http/server.go:1728 +0x92
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net/http.(*Server).ListenAndServe(0xc208036540, 0x0, 0x0)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/http/server.go:1718 +0x154
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: net/http.ListenAndServe(0xa68730, 0x5, 0x7fb67c3b5998, 0xc20801ec20, 0x0, 0x0)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/net/http/server.go:1808 +0xba
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: main.main()
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /aggregate-healthcheck/main.go:61 +0x1038
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: goroutine 17 [syscall, 1 minutes, locked to thread]:
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: runtime.goexit()
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /usr/lib/go/src/runtime/asm_amd64.s:2232 +0x1
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: goroutine 7 [select]:
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: main.(*hchandlers).loop(0xc2080101c0, 0xc208036240, 0xc208036300)
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /aggregate-healthcheck/handlers.go:69 +0x9c3
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: created by main.NewHCHandlers
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: /aggregate-healthcheck/handlers.go:45 +0x251
Dec 29 10:05:54 ip-172-24-80-191.eu-west-1.compute.internal bash[8877]: goroutine 8 [select, 1 minutes]:
...
```